### PR TITLE
AddingPowerSupport_For_golang-github-rfjakob-eme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch:
+  - amd64
+  - ppc64le
+  
 language: go
 
 go:


### PR DESCRIPTION
Adding power Support.

Adding power support ppc64le.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/eme

Please let me know if you need any further details?

Thank You !!